### PR TITLE
Fix App Item Icon not loaded correctly

### DIFF
--- a/launcher_app/src/main/java/id/psw/vshlauncher/submodules/XMBAdaptiveIconRenderer.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/submodules/XMBAdaptiveIconRenderer.kt
@@ -142,7 +142,8 @@ class XMBAdaptiveIconRenderer(private val ctx: VSH) : IVshSubmodule {
             }
 
             for(i in 0 .. 3){
-                when(getIconPriorityAt(i)){
+                val prio = getIconPriorityAt(i)
+                when(prio){
                     ICON_PRIORITY_TYPE_APP_ICON_ADAPTIVE -> {
                         if(icon is AdaptiveIconDrawable){
                             drawFittedBitmap(ctx, icon.background, BackScale, BackXAnchor, BackYAnchor, drawRect)

--- a/launcher_app/src/main/java/id/psw/vshlauncher/types/CIFLoader.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/types/CIFLoader.kt
@@ -186,7 +186,6 @@ class CIFLoader {
     fun unloadIcon(){
 
         if(_icon.id != default_bitmap.id) _icon.release()
-        _icon = default_bitmap
 
         synchronized(_animIconSync){
             if(_hasAnimIconLoaded || !_animIcon.hasRecycled){

--- a/launcher_app/src/main/java/id/psw/vshlauncher/types/items/XMBAppItem.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/types/items/XMBAppItem.kt
@@ -67,7 +67,6 @@ class XMBAppItem(private val vsh: VSH, val resInfo : ResolveInfo) : XMBItem(vsh)
     }
 
     private var _customAppDesc: String =""
-    private var _icon = TRANSPARENT_BITMAP
 
     private val iconId : String = "${resInfo.activityInfo.processName}::${resInfo.activityInfo.packageName}"
     private var appLabel = ""
@@ -85,7 +84,7 @@ class XMBAppItem(private val vsh: VSH, val resInfo : ResolveInfo) : XMBItem(vsh)
 
     private val cif = CIFLoader(vsh, resInfo, FileQuery(VshBaseDirs.APPS_DIR).withNames(resInfo.uniqueActivityName).execute(vsh))
 
-    override val isIconLoaded: Boolean get()= cif.hasIconLoaded
+    override val isIconLoaded: Boolean get()= cif.icon.isLoaded
     override val isAnimatedIconLoaded: Boolean get() = cif.hasAnimIconLoaded
     override val isBackSoundLoaded: Boolean get() = cif.hasBackSoundLoaded
     override val isBackdropLoaded: Boolean get() = cif.hasBackdropLoaded
@@ -390,6 +389,10 @@ class XMBAppItem(private val vsh: VSH, val resInfo : ResolveInfo) : XMBItem(vsh)
                     vsh.doCategorySorting()
                 }
             )
+
+            // TODO: Create Real BitmapRef at start, this is just a patch
+            cif.loadIcon()
+            cif.unloadIcon()
         }
     }
 
@@ -451,7 +454,7 @@ class XMBAppItem(private val vsh: VSH, val resInfo : ResolveInfo) : XMBItem(vsh)
     private fun pOnScreenVisible(i : XMBItem){
         vsh.threadPool.execute {
             appLabel = resInfo.loadLabel(vsh.packageManager).toString()
-            if(_icon == TRANSPARENT_BITMAP){
+            if(!cif.icon.isLoaded){
                 cif.loadIcon()
             }
         }
@@ -461,7 +464,7 @@ class XMBAppItem(private val vsh: VSH, val resInfo : ResolveInfo) : XMBItem(vsh)
         // Destroy icon, Unload it from memory
         vsh.threadPool.execute {
             if(vsh.aggressiveUnloading){
-                if(_icon != TRANSPARENT_BITMAP){
+                if(cif.icon.isLoaded){
                     cif.unloadIcon()
                 }
             }


### PR DESCRIPTION
Previously, the icons in the app list is either empty or is loaded but not unloaded correctly when is out of screen, making changing icon type load priority requires launcher restart before is applied.