### PR TITLE
Migrate from Thread to Kotlin Coroutines

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,23 @@ see [Main Project](https://github.com/EmiyaSyahriel/CrossLauncher/projects/1)
 ## Supported customizations
 see [Supported customization](https://github.com/EmiyaSyahriel/CrossLauncher/wiki/Customization)
 
-## Releases
-You can build it yourself, Or go to [Release](https://github.com/EmiyaSyahriel/CrossLauncher/releases)
-page for pre-built packages
+## Download
+There is 2 type of download now:
+- [Action Build](https://github.com/EmiyaSyahriel/CrossLauncher/actions/workflows/android.yml)
+  - Not really stable most of the time
+  - Updated every time a new code is pushed to repository
+  - Debug only, not for everyday use.
+  - How to download
+    - Select latest workflow with green check
+    - Open Summary (opened by default)
+    - Go to lowermost part, where it says *Artifacts*
+    - Download the APK
+- [Stable Release](https://github.com/EmiyaSyahriel/CrossLauncher/releases)
+  - Stable, at least more than Action Build version
+  - Updated less frequently
+  - Have both Release and Debug
+
+Or you can build it yourself, see [Building](#building) section.
 
 ## Building
 ### Prerequisites

--- a/launcher_app/build.gradle.kts
+++ b/launcher_app/build.gradle.kts
@@ -89,6 +89,12 @@ dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar") )))
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("androidx.core:core-ktx:1.10.1")
+
+    // Kotlin Coroutine
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9")
+    implementation("androidx.lifecycle:lifecycle-process:2.4.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.4.0")
+
     implementation("androidx.media:media:1.6.0")
     implementation("com.github.penfeizhou.android.animation:awebp:2.17.2")
     implementation("com.github.penfeizhou.android.animation:apng:2.17.2")

--- a/launcher_app/src/main/java/id/psw/vshlauncher/VSH.Settings.1.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/VSH.Settings.1.kt
@@ -6,8 +6,6 @@ import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.app.ActivityCompat
-import id.psw.vshlauncher.submodules.GamepadSubmodule
-import id.psw.vshlauncher.submodules.GamepadUISubmodule
 import id.psw.vshlauncher.submodules.PadKey
 import id.psw.vshlauncher.submodules.PadType
 import id.psw.vshlauncher.submodules.XMBAdaptiveIconRenderer
@@ -17,6 +15,7 @@ import id.psw.vshlauncher.views.XMBLayoutType
 import id.psw.vshlauncher.views.dialogviews.*
 import id.psw.vshlauncher.views.formatStatusBar
 import id.psw.vshlauncher.views.showDialog
+import kotlinx.coroutines.*
 import java.util.*
 import kotlin.collections.ArrayList
 import kotlin.math.roundToInt
@@ -32,14 +31,13 @@ object SettingsCategoryID {
 }
 
 fun VSH.fillSettingsCategory(){
-    threadPool.execute {
+    vsh.lifeScope.launch {
         addToCategory(VSH.ITEM_CATEGORY_SETTINGS, createCategoryDisplay())
         addToCategory(VSH.ITEM_CATEGORY_SETTINGS, createCategoryAudio())
         addToCategory(VSH.ITEM_CATEGORY_SETTINGS, createCategorySystem())
         addToCategory(VSH.ITEM_CATEGORY_SETTINGS, createCategoryAndroidSetting())
         addToCategory(VSH.ITEM_CATEGORY_SETTINGS, createCategoryDebug())
         addToCategory(VSH.ITEM_CATEGORY_SETTINGS, settingsAddInstallPackage())
-
     }
 }
 

--- a/launcher_app/src/main/java/id/psw/vshlauncher/VSH.Settings.2.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/VSH.Settings.2.kt
@@ -18,6 +18,10 @@ import id.psw.vshlauncher.views.VshViewPage
 import id.psw.vshlauncher.views.dialogviews.LegacyIconBackgroundDialogView
 import id.psw.vshlauncher.views.dialogviews.TextDialogView
 import id.psw.vshlauncher.views.showDialog
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 
 private var settingWaveCurrentWaveStyle = XMBWaveRenderer.WAVE_TYPE_PS3_NORMAL
@@ -84,8 +88,17 @@ fun VSH.createCategoryWaveSetting(): XMBSettingsCategory {
                     getString(R.string.settings_wave_apply_as_layer_dlg_text_main))
                     .setPositive(getString(R.string.common_reboot)){_ ->
                         // Commit instead of apply, allow the app to save the preference before restarting
-                        M.pref.set(PrefEntry.USES_INTERNAL_WAVE_LAYER, !vsh.useInternalWave)
-                        vsh.restart()
+                        M.pref
+                            .set(PrefEntry.USES_INTERNAL_WAVE_LAYER, !vsh.useInternalWave)
+                            .push()
+
+                        vsh.lifeScope.launch {
+                            withContext(Dispatchers.Default){
+                                delay(1000L)
+                                vsh.restart()
+                            }
+                        }
+
                     }
                     .setNegative(getString(android.R.string.cancel)){dlg -> dlg.finish(VshViewPage.MainMenu) }
             )

--- a/launcher_app/src/main/java/id/psw/vshlauncher/VSH.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/VSH.kt
@@ -64,6 +64,7 @@ class VSH : Application() {
     var xmbView : XmbView? = null
     var playAnimatedIcon = true
     var mediaListingStarted = false
+    lateinit var mainHandle : Handler
 
     val categories = arrayListOf<XMBItemCategory>()
     /** Return all item in current selected category or current active item, including the hidden ones */
@@ -146,7 +147,7 @@ class VSH : Application() {
 
     override fun onCreate() {
         Logger.init(this)
-
+        mainHandle = Handler(mainLooper)
         isTv = if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
             packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
         }else{

--- a/launcher_app/src/main/java/id/psw/vshlauncher/VSH.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/VSH.kt
@@ -14,8 +14,10 @@ import androidx.annotation.DrawableRes
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.graphics.scale
+import androidx.lifecycle.LifecycleCoroutineScope
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import id.psw.vshlauncher.livewallpaper.NativeGL
-// import com.facebook.drawee.backends.pipeline.Fresco
 import id.psw.vshlauncher.submodules.*
 import id.psw.vshlauncher.types.*
 import id.psw.vshlauncher.types.Stack
@@ -132,6 +134,7 @@ class VSH : Application() {
     var shouldShowExitOption = false
 
     var useInternalWave = true
+    var lifeScope : LifecycleCoroutineScope = ProcessLifecycleOwner.get().lifecycleScope
 
     private fun reloadPreference() {
         setActiveLocale(readSerializedLocale(M.pref.get(PrefEntry.SYSTEM_LANGUAGE, "")))

--- a/launcher_app/src/main/java/id/psw/vshlauncher/activities/XMB.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/activities/XMB.kt
@@ -220,8 +220,6 @@ class XMB : AppCompatActivity() {
                 MotionEvent.AXIS_X,
                 MotionEvent.AXIS_Y,
                 MotionEvent.AXIS_Z,
-                MotionEvent.AXIS_HAT_X,
-                MotionEvent.AXIS_HAT_Y,
                 MotionEvent.AXIS_RX,
                 MotionEvent.AXIS_RY,
                 MotionEvent.AXIS_RZ,
@@ -230,7 +228,7 @@ class XMB : AppCompatActivity() {
                 if(abs(value) > 0.1f){
                     val k = M.gamepad.translateAxis(it, value, event.device.vendorId, event.device.productId)
                     if(k != PadKey.None){
-                        retval = xmbView.onGamepadInput(k, true)
+                        retval = xmbView.onGamepadInput(k, event.actionMasked == MotionEvent.ACTION_DOWN)
                     }
                 }
             }

--- a/launcher_app/src/main/java/id/psw/vshlauncher/submodules/XMBAdaptiveIconRenderer.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/submodules/XMBAdaptiveIconRenderer.kt
@@ -142,7 +142,8 @@ class XMBAdaptiveIconRenderer(private val ctx: VSH) : IVshSubmodule {
             }
 
             for(i in 0 .. 3){
-                when(getIconPriorityAt(i)){
+                val prio = getIconPriorityAt(i)
+                when(prio){
                     ICON_PRIORITY_TYPE_APP_ICON_ADAPTIVE -> {
                         if(icon is AdaptiveIconDrawable){
                             drawFittedBitmap(ctx, icon.background, BackScale, BackXAnchor, BackYAnchor, drawRect)

--- a/launcher_app/src/main/java/id/psw/vshlauncher/types/CIFLoader.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/types/CIFLoader.kt
@@ -186,7 +186,6 @@ class CIFLoader {
     fun unloadIcon(){
 
         if(_icon.id != default_bitmap.id) _icon.release()
-        _icon = default_bitmap
 
         synchronized(_animIconSync){
             if(_hasAnimIconLoaded || !_animIcon.hasRecycled){

--- a/launcher_app/src/main/java/id/psw/vshlauncher/types/items/XMBAppItem.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/types/items/XMBAppItem.kt
@@ -427,30 +427,6 @@ class XMBAppItem(private val vsh: VSH, val resInfo : ResolveInfo) : XMBItem(vsh)
         }.execute(vsh)
     }
 
-    private fun pIconLoad(){
-        cif.loadIcon()
-    }
-
-    private fun pIconUnload(){
-        cif.unloadIcon()
-    }
-
-    private fun pBackdropLoad(){
-        cif.loadBackdrop()
-    }
-
-    private fun pBackdropUnload(){
-        cif.unloadBackdrop()
-    }
-
-    private fun pSoundLoad(){
-        cif.loadSound()
-    }
-
-    private fun pSoundUnload(){
-        cif.unloadSound()
-    }
-
     private fun pOnScreenVisible(i : XMBItem){
         vsh.threadPool.execute {
             appLabel = resInfo.loadLabel(vsh.packageManager).toString()

--- a/launcher_app/src/main/java/id/psw/vshlauncher/types/items/XMBAppItem.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/types/items/XMBAppItem.kt
@@ -67,7 +67,6 @@ class XMBAppItem(private val vsh: VSH, val resInfo : ResolveInfo) : XMBItem(vsh)
     }
 
     private var _customAppDesc: String =""
-    private var _icon = TRANSPARENT_BITMAP
 
     private val iconId : String = "${resInfo.activityInfo.processName}::${resInfo.activityInfo.packageName}"
     private var appLabel = ""
@@ -85,7 +84,7 @@ class XMBAppItem(private val vsh: VSH, val resInfo : ResolveInfo) : XMBItem(vsh)
 
     private val cif = CIFLoader(vsh, resInfo, FileQuery(VshBaseDirs.APPS_DIR).withNames(resInfo.uniqueActivityName).execute(vsh))
 
-    override val isIconLoaded: Boolean get()= cif.hasIconLoaded
+    override val isIconLoaded: Boolean get()= cif.icon.isLoaded
     override val isAnimatedIconLoaded: Boolean get() = cif.hasAnimIconLoaded
     override val isBackSoundLoaded: Boolean get() = cif.hasBackSoundLoaded
     override val isBackdropLoaded: Boolean get() = cif.hasBackdropLoaded
@@ -390,6 +389,10 @@ class XMBAppItem(private val vsh: VSH, val resInfo : ResolveInfo) : XMBItem(vsh)
                     vsh.doCategorySorting()
                 }
             )
+
+            // TODO: Create Real BitmapRef at start, this is just a patch
+            cif.loadIcon()
+            cif.unloadIcon()
         }
     }
 
@@ -451,7 +454,7 @@ class XMBAppItem(private val vsh: VSH, val resInfo : ResolveInfo) : XMBItem(vsh)
     private fun pOnScreenVisible(i : XMBItem){
         vsh.threadPool.execute {
             appLabel = resInfo.loadLabel(vsh.packageManager).toString()
-            if(_icon == TRANSPARENT_BITMAP){
+            if(!cif.icon.isLoaded){
                 cif.loadIcon()
             }
         }
@@ -461,7 +464,7 @@ class XMBAppItem(private val vsh: VSH, val resInfo : ResolveInfo) : XMBItem(vsh)
         // Destroy icon, Unload it from memory
         vsh.threadPool.execute {
             if(vsh.aggressiveUnloading){
-                if(_icon != TRANSPARENT_BITMAP){
+                if(cif.icon.isLoaded){
                     cif.unloadIcon()
                 }
             }

--- a/launcher_app/src/main/java/id/psw/vshlauncher/views/XmbView.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/views/XmbView.kt
@@ -1,7 +1,6 @@
 package id.psw.vshlauncher.views
 
 import android.content.Context
-import android.content.pm.PackageManager
 import android.graphics.*
 import android.os.Build
 import android.os.Debug
@@ -14,7 +13,6 @@ import androidx.core.graphics.withScale
 import androidx.core.graphics.withTranslation
 import id.psw.vshlauncher.*
 import id.psw.vshlauncher.activities.XMB
-import id.psw.vshlauncher.submodules.GamepadSubmodule
 import id.psw.vshlauncher.submodules.PadKey
 import id.psw.vshlauncher.typography.FontCollections
 import java.util.*

--- a/launcher_app/src/main/java/id/psw/vshlauncher/views/dialogviews/ArrangeCategoryDialogView.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/views/dialogviews/ArrangeCategoryDialogView.kt
@@ -165,16 +165,18 @@ class ArrangeCategoryDialogView(private val vsh: VSH) :  XmbDialogSubview(vsh) {
     }
 
     override fun onGamepad(key: PadKey, isPress: Boolean): Boolean {
-        when(key){
+
+        return if(isPress) when(key){
             PadKey.PadL -> {
                 setActiveIndex(activeIndex - 1)
+                true
             }
             PadKey.PadR -> {
                 setActiveIndex(activeIndex + 1)
+                true
             }
-            else -> { } // Nothing to do
-        }
-        return super.onGamepad(key, isPress)
+            else -> super.onGamepad(key, true)
+        } else super.onGamepad(key, false)
     }
 
     override fun onDialogButton(isPositive: Boolean) {


### PR DESCRIPTION
A resource usage suppression, using coroutine, this suppresses individual, single-purpose thread count, which each thread uses a part of resources that can be allocated for other uses.

This PR also includes :
- Fix for Gamepad (and possibly Remocon) D-pad event detected twice (One from `OnKeyUp/Down` callback pair, and the other is from `OnGenericMotion`).
  - You can still hold-press them for fast navigation, this is how Android `OnKeyUp/Down` pair worked.
- Adds feature to open Item Menu by holding *Confirm* Button (on Gamepad and possibly Remocon)
- Fix Internal Live Wallpaper Usage setting not saved due to app process being killed before preference is saved.
- Fix `Arrange Category Settings` moves L/R by two item instead of one.