### PR TITLE
fix wave coldboot and wave surface recreation bg color reset

### DIFF
--- a/launcher_app/src/main/cpp/wave/BACKGRND.CPP
+++ b/launcher_app/src/main/cpp/wave/BACKGRND.CPP
@@ -13,10 +13,15 @@ void cxl_bg_start(){
     wave_state.bg.TEXCOORD =   glGetAttribLocation (wave_state.bg.program, wave_consts.attr_names.TEXCOORD0);
 
     //wave_state.bg_mode = (AUTO_BG_MODE)((int8_t)AUTO_BG_MODE::DAY_NIGHT | (int8_t)AUTO_BG_MODE::MONTHLY);
-    wave_state.bg_month = MONTH_COLOR_INDEX::MONTH_CURRENT;
-    wave_state.colors.bg_a = vec3(0.0f, 1.0f, 1.0f);
-    wave_state.colors.bg_b = vec3(0.0f, 0.0f, 1.0f);
     wave_state.vert_scale = 1.0f;
+
+    /* XMBWaveSurfaceView will call setBackgroundMonth and setBackgroundColor
+     * Every time the surface view gets out of view, GLSurfaceView will also re-run onSurfaceCreated
+     * Setting these here during surface recreation will cause a preference desync
+     */
+    //wave_state.bg_month = MONTH_COLOR_INDEX::MONTH_CURRENT;
+    //wave_state.colors.bg_a = vec3(0.0f, 1.0f, 1.0f);
+    //wave_state.colors.bg_b = vec3(0.0f, 0.0f, 1.0f);
 }
 
 void cxl_bg_draw(){

--- a/launcher_app/src/main/java/id/psw/vshlauncher/views/screens/XmbColdboot.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/views/screens/XmbColdboot.kt
@@ -18,6 +18,7 @@ import id.psw.vshlauncher.VshResTypes
 import id.psw.vshlauncher.getDrawable
 import id.psw.vshlauncher.lerpFactor
 import id.psw.vshlauncher.livewallpaper.NativeGL
+import id.psw.vshlauncher.livewallpaper.XMBWaveRenderer
 import id.psw.vshlauncher.livewallpaper.XMBWaveSurfaceView
 import id.psw.vshlauncher.makeTextPaint
 import id.psw.vshlauncher.submodules.PadKey
@@ -38,9 +39,9 @@ class XmbColdboot(view : XmbView) : XmbScreen(view) {
     }
     private var isL1Down = false
     private val epiwarnPaint = vsh.makeTextPaint(size = 20.0f, color = Color.WHITE)
-    private var waveSpeed = 1.0f
     var hideEpilepsyWarning = false
-    var transition = 0.0f
+
+    private var waveVerticalScale = 0.1f;
 
     private fun playColdBootSound(){
         var isFound = false
@@ -90,8 +91,8 @@ class XmbColdboot(view : XmbView) : XmbScreen(view) {
 
     override fun render(ctx: Canvas) {
         ensureImageLoaded()
-        NativeGL.setSpeed(0.0f)
-        NativeGL.setVerticalScale(0.0f)
+        NativeGL.setSpeed(0.5f)
+        NativeGL.setVerticalScale(waveVerticalScale)
 
         val img = image
         val cTime = currentTime
@@ -148,12 +149,11 @@ class XmbColdboot(view : XmbView) : XmbScreen(view) {
         currentTime = 0.0f
         ensureImageLoaded()
         playColdBootSound()
-        transition = 1.0f
         val pref = context.vsh.getSharedPreferences(XMBWaveSurfaceView.PREF_NAME, Context.MODE_PRIVATE)
-
-        waveSpeed = pref.getFloat(XMBWaveSurfaceView.KEY_SPEED, 1.0f)
-        NativeGL.setSpeed(0.0f)
-        NativeGL.setVerticalScale(0.0f)
+        val waveType = pref.getInt(XMBWaveSurfaceView.KEY_STYLE, XMBWaveRenderer.WAVE_TYPE_PS3_BLINKS.toInt()).toByte()
+        if(waveType == XMBWaveRenderer.WAVE_TYPE_PSP_CENTER){
+            waveVerticalScale = 0.5f;
+        }
     }
 
     override fun end(){


### PR DESCRIPTION
Do not set background color during cxl_bg_start since android would re-invoke onSurfaceCreated every time the view transitions from invisible to visible

Wave background cold boot seems to have been lost during the last refactoring, adding that back as well

Thanks for working on this launcher, it looks amazing :ok_hand: 

<img width=600px src=https://github.com/EmiyaSyahriel/CrossLauncher/assets/22017945/2b348308-2073-47b0-a8a9-c94704af1d71>
