### PR TITLE
make <= 100px bitmap icons less blurry and unify their sizes

### DIFF
--- a/launcher_app/src/main/java/id/psw/vshlauncher/Vsh.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/Vsh.kt
@@ -54,6 +54,7 @@ class Vsh : Application() {
         const val COPY_DATA_SIZE_BUFFER = 10240
         const val ACT_REQ_INSTALL_PACKAGE = 4496
         const val ACT_REQ_MEDIA_LISTING = 0x9121
+        const val ITEM_BUILTIN_ICON_BITMAP_SIZE = 300
 
         val dbgMemInfo = Debug.MemoryInfo()
         val actMemInfo = ActivityManager.MemoryInfo()

--- a/launcher_app/src/main/java/id/psw/vshlauncher/types/items/XmbAndroidSettingShortcutItem.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/types/items/XmbAndroidSettingShortcutItem.kt
@@ -24,7 +24,7 @@ class XmbAndroidSettingShortcutItem(
     override val isIconLoaded: Boolean = true
     override val icon: Bitmap = ResourcesCompat
         .getDrawable(vsh.resources, iconId, null)
-        ?.toBitmap(50,50)
+        ?.toBitmap(Vsh.ITEM_BUILTIN_ICON_BITMAP_SIZE,Vsh.ITEM_BUILTIN_ICON_BITMAP_SIZE)
         ?: TRANSPARENT_BITMAP
     override val hasIcon: Boolean
         get() = icon != TRANSPARENT_BITMAP

--- a/launcher_app/src/main/java/id/psw/vshlauncher/types/items/XmbItemCategory.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/types/items/XmbItemCategory.kt
@@ -74,14 +74,14 @@ class XmbItemCategory(
                 for(file in cFiles){
                     try{
                         val srcb =BitmapFactory.decodeFile(file.absolutePath)
-                        cbmp = srcb?.scale(300, 300)
+                        cbmp = srcb?.scale(Vsh.ITEM_BUILTIN_ICON_BITMAP_SIZE, Vsh.ITEM_BUILTIN_ICON_BITMAP_SIZE)
                         srcb.recycle()
                     }catch(_:Exception){
                     }
                 }
 
                 cbmp ?:
-                    ResourcesCompat.getDrawable(vsh.resources, iconId, null)?.toBitmap(300,300)
+                    ResourcesCompat.getDrawable(vsh.resources, iconId, null)?.toBitmap(Vsh.ITEM_BUILTIN_ICON_BITMAP_SIZE,Vsh.ITEM_BUILTIN_ICON_BITMAP_SIZE)
                     ?: TRANSPARENT_BITMAP
             })
 

--- a/launcher_app/src/main/java/id/psw/vshlauncher/types/items/XmbSettingsCategory.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/types/items/XmbSettingsCategory.kt
@@ -14,7 +14,7 @@ class XmbSettingsCategory(
     private val descResId : Int
 ) :
     XmbItem(vsh) {
-    override val icon : Bitmap = ResourcesCompat.getDrawable(vsh.resources, iconResId, null)!!.toBitmap(100,100)
+    override val icon : Bitmap = ResourcesCompat.getDrawable(vsh.resources, iconResId, null)!!.toBitmap(Vsh.ITEM_BUILTIN_ICON_BITMAP_SIZE,Vsh.ITEM_BUILTIN_ICON_BITMAP_SIZE)
     override val displayName: String get() = vsh.getString(nameResId)
     override val description: String get() = vsh.getString(descResId)
     override val content: ArrayList<XmbItem> = arrayListOf()

--- a/launcher_app/src/main/java/id/psw/vshlauncher/types/items/XmbSettingsItem.kt
+++ b/launcher_app/src/main/java/id/psw/vshlauncher/types/items/XmbSettingsItem.kt
@@ -23,7 +23,7 @@ class XmbSettingsItem(
     override var menuItems: ArrayList<XmbMenuItem>? = null
     override val hasIcon: Boolean = true
     override val isIconLoaded: Boolean = true
-    override val icon = ResourcesCompat.getDrawable(vsh.resources, r_icon, null)?.toBitmap(256,256) ?: TRANSPARENT_BITMAP
+    override val icon = ResourcesCompat.getDrawable(vsh.resources, r_icon, null)?.toBitmap(Vsh.ITEM_BUILTIN_ICON_BITMAP_SIZE,Vsh.ITEM_BUILTIN_ICON_BITMAP_SIZE) ?: TRANSPARENT_BITMAP
     override val isHidden: Boolean get() = checkIsHidden()
     var checkIsHidden : () -> Boolean = {
         false


### PR DESCRIPTION
Unify icons bitmap size to 300x300, the largest size as far as I can find in the current codebase

Fixes blurriness of icons with 50x50 and 100x100 bitmaps